### PR TITLE
Filter out SQLCop tests from the Invalid Objects test

### DIFF
--- a/Current/Invalid Objects.sql
+++ b/Current/Invalid Objects.sql
@@ -47,7 +47,8 @@ BEGIN
     WHERE dep.is_ambiguous = 0
           AND dep.referenced_id IS NULL
           AND dep.referenced_schema_name <> 'tSQLt'
-          AND SCHEMA_NAME(ob.schema_id) <> 'tSQLt';
+          AND SCHEMA_NAME(ob.schema_id) <> 'tSQLt'
+          AND SCHEMA_NAME(ob.schema_id) <> 'SQLCop';
 
     -- Assert
     -- Check if output is blank and pass, else fail with list of invalid objects


### PR DESCRIPTION
Several tests in SQL Cop reference DMVs that only exist in on-prem SQL Server or only in Azure, and switch based on what server they are run on. This causes them to fail the Invalid Objects test. This is not useful to users of SQL Cop.