### PR TITLE
fix(#13): "Invalid objects" check fails with cross database calls

### DIFF
--- a/Current/Invalid Objects.sql
+++ b/Current/Invalid Objects.sql
@@ -46,6 +46,7 @@ BEGIN
             ON ob.object_id = dep.referencing_id
     WHERE dep.is_ambiguous = 0
           AND dep.referenced_id IS NULL
+          AND dep.referenced_database_name = db_name()
           AND dep.referenced_schema_name <> 'tSQLt'
           AND SCHEMA_NAME(ob.schema_id) <> 'tSQLt'
           AND SCHEMA_NAME(ob.schema_id) <> 'SQLCop';


### PR DESCRIPTION
When querying the referenced database, checks that the invalid reference is in the same database where the test is being executed, otherwise the test will always fail if the reference is in another database on the same server.

There may be a better fix for this dynamically inspect the results and see if the database name is the same?