### PR TITLE
Ensure TeamCity captures stderr output

### DIFF
--- a/.build/_init.ps1
+++ b/.build/_init.ps1
@@ -12,7 +12,7 @@ function global:RestoreBuildLevelPackages {
 
     Push-Location $PsScriptRoot -verbose
     try {
-        & "..\.paket\paket.exe" install
+        & cmd /c "..\.paket\paket.exe install 2>&1"
         if($LASTEXITCODE -ne 0) {
             throw "paket install exited with code $LASTEXITCODE"
         }


### PR DESCRIPTION
When a non-PowerShell command fails on TeamCity, and there is output on stderr, that output gets truncated to the first line only. By redirecting stderr to stdout, all the error message is captured.

This is applicable to all non-PowerShell commands, not just paket. If you want to, please do apply this change to other commands that output to stderr! (vagrant is another one that often hits this problem.)